### PR TITLE
YahooAuth refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 drivers
 pyenv
 *.pyc
+cookies.pkl

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,10 +5,15 @@
 * Store schedule data in JSON file
 * Get current year and use corresponding JSON file
 
+## Headless-mode
+
+* Prompt username and password
+
 ## Login
 
 1. Default: Manual user input with 2 min limit
 2. --username <username> and manual password input with 2 min limit
+
 
 ## --league
 * League ID

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,6 +14,12 @@
 1. Default: Manual user input with 2 min limit
 2. --username <username> and manual password input with 2 min limit
 
+## Cache rosters
+
+* --cached      use previously saved rosters instead of fetching live data which is slower
+OR
+* --refresh     fetch live data from Yahoo to update cached rosters           
+
 
 ## --league
 * League ID

--- a/config.py
+++ b/config.py
@@ -1,13 +1,3 @@
-from selenium.webdriver.chrome.options import Options
-import os
-
-chrome_options = Options()
-
-headless_chrome_options = Options()
-headless_chrome_options.add_argument("--headless")
-headless_chrome_options.add_argument("--disable-gpu")
-
-
 YAHOO_FANTASY_URL = "https://basketball.fantasysports.yahoo.com"
 YAHOO_NBA_FANTASY_URL = "https://basketball.fantasysports.yahoo.com/nba/"
 CURRENT_SEASON = 2017

--- a/config.py
+++ b/config.py
@@ -1,5 +1,12 @@
 from selenium.webdriver.chrome.options import Options
+import os
 
 headless_chrome_options = Options()
-headless_chrome_options.add_argument("--headless")
-headless_chrome_options.add_argument("--disable-gpu")
+# headless_chrome_options.add_argument("--headless")
+# headless_chrome_options.add_argument("--disable-gpu")
+
+
+YAHOO_FANTASY_URL = "https://basketball.fantasysports.yahoo.com"
+YAHOO_NBA_FANTASY_URL = "https://basketball.fantasysports.yahoo.com/nba/"
+CURRENT_SEASON = 2017
+DATA_DIR = 'data'

--- a/config.py
+++ b/config.py
@@ -1,9 +1,11 @@
 from selenium.webdriver.chrome.options import Options
 import os
 
+chrome_options = Options()
+
 headless_chrome_options = Options()
-# headless_chrome_options.add_argument("--headless")
-# headless_chrome_options.add_argument("--disable-gpu")
+headless_chrome_options.add_argument("--headless")
+headless_chrome_options.add_argument("--disable-gpu")
 
 
 YAHOO_FANTASY_URL = "https://basketball.fantasysports.yahoo.com"

--- a/roster_repository.py
+++ b/roster_repository.py
@@ -7,7 +7,7 @@ from selenium.webdriver.support import expected_conditions as expect
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from bs4 import BeautifulSoup
 
-from config import headless_chrome_options, YAHOO_FANTASY_URL, YAHOO_NBA_FANTASY_URL
+from config import chrome_options, headless_chrome_options, YAHOO_FANTASY_URL, YAHOO_NBA_FANTASY_URL
 from yahoo_auth import YahooAuth
 
 TEAM_NAME_CLASS = "Mawpx-250"
@@ -17,8 +17,13 @@ PLAYER_NAME_CLASS = "ysf-player-name"
 
 
 class RosterRepository(object):
-    def __init__(self):
-        self._driver = webdriver.Chrome(chrome_options=headless_chrome_options)
+    def __init__(self, **kwargs):
+        try:
+            self._headless = kwargs['headless']
+        except KeyError:
+            self._headless = False
+        
+        self._driver = webdriver.Chrome(chrome_options=self._pick_driver_options())
         self._wait = WebDriverWait(self._driver, 10, poll_frequency=0.25)
 
     @YahooAuth.ensures_login(YAHOO_NBA_FANTASY_URL)
@@ -110,6 +115,10 @@ class RosterRepository(object):
             })
 
         return teams_info
+
+
+    def _pick_driver_options(self):
+        return headless_chrome_options if self._headless else chrome_options
 
 
     def _assert_current_page_matches_league(self):

--- a/roster_repository.py
+++ b/roster_repository.py
@@ -1,13 +1,14 @@
+import re
+import sys
+from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as expect
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from bs4 import BeautifulSoup
-import re
-import sys
 
-from config import YAHOO_FANTASY_URL
-
+from config import headless_chrome_options, YAHOO_FANTASY_URL, YAHOO_NBA_FANTASY_URL
+from yahoo_auth import YahooAuth
 
 TEAM_NAME_CLASS = "Mawpx-250"
 WIN_LOSS_DRAW_CLASS = "Tst-wlt"
@@ -16,10 +17,11 @@ PLAYER_NAME_CLASS = "ysf-player-name"
 
 
 class RosterRepository(object):
-    def __init__(self, driver):
-        self._driver = driver
+    def __init__(self):
+        self._driver = webdriver.Chrome(chrome_options=headless_chrome_options)
         self._wait = WebDriverWait(self._driver, 10, poll_frequency=0.25)
 
+    @YahooAuth.ensures_login(YAHOO_NBA_FANTASY_URL)
     def get_active_rosters(self, league_id):
         self._assert_current_page_matches_league()
         teams_info = self._get_teams_info()
@@ -111,6 +113,6 @@ class RosterRepository(object):
 
 
     def _assert_current_page_matches_league(self):
-        if not re.search(YAHOO_FANTASY_URL + '/nba/\d+.*?$', self._driver.current_url):
+        if not re.search(YAHOO_NBA_FANTASY_URL + '\d+.*?$', self._driver.current_url):
             print("Current page is not a league page. Exiting.")
             sys.exit()

--- a/schedule_repository.py
+++ b/schedule_repository.py
@@ -17,5 +17,6 @@ class ScheduleRepository(object):
             return json.load(datafile)
         return {}
     
+
     def _get_datafile_path(self):
         return os.path.join(DATA_DIR, SCHEDULE_DATA_DIR, '{}.json'.format(CURRENT_SEASON))

--- a/weekly_team_games_counter.py
+++ b/weekly_team_games_counter.py
@@ -4,19 +4,19 @@ import json
 
 from schedule_repository import ScheduleRepository
 from roster_repository import RosterRepository
-from config import headless_chrome_options, YAHOO_FANTASY_URL
+from config import YAHOO_FANTASY_URL
 from utils.timer import timer
 
 class WeeklyTeamGamesCounter(object):
-    def __init__(self, **kwargs):
+    def __init__(self):
         self._sched_repo = ScheduleRepository()
-        self._roster_repo = RosterRepository(**kwargs)
+        self._roster_repo = RosterRepository()
     
 
     @timer
-    def main(self, league_id, weeks, **kwargs):
+    def main(self, league_id, weeks):
         weekly_games_per_team = self._sched_repo.get_weekly_game_count_per_team(weeks)
-        team_rosters = self._roster_repo.get_active_rosters(league_id, **kwargs)
+        team_rosters = self._roster_repo.get_active_rosters(league_id)
         self._generate_games_per_week(weekly_games_per_team, team_rosters)
 
 
@@ -35,6 +35,7 @@ class WeeklyTeamGamesCounter(object):
         with open('weekly_team_games.json', 'w') as outfile:
             json.dump(weekly_games_per_team, outfile)
 
+
     def _generate_team_games_for_week(self, team, player_count_per_nba_team, games_per_nba_team):
         team_games_this_week = 0
 
@@ -44,6 +45,7 @@ class WeeklyTeamGamesCounter(object):
             for nba_team, player_count in player_count_per_nba_team[team["name"]].items():
                 team_games_this_week = team_games_this_week + (games_per_nba_team[nba_team] * player_count)
         return team_games_this_week
+
 
     def _count_team_games_and_update_player_count(self, player_count_per_nba_team, team, team_games_this_week, games_per_nba_team):
         player_count_per_nba_team[team["name"]] = {}
@@ -64,5 +66,5 @@ class WeeklyTeamGamesCounter(object):
 
 
 if __name__ == "__main__":
-    games_counter = WeeklyTeamGamesCounter(headless=True)
+    games_counter = WeeklyTeamGamesCounter()
     games_counter.main(50972, [22, 23, 24])

--- a/weekly_team_games_counter.py
+++ b/weekly_team_games_counter.py
@@ -8,15 +8,15 @@ from config import headless_chrome_options, YAHOO_FANTASY_URL
 from utils.timer import timer
 
 class WeeklyTeamGamesCounter(object):
-    def __init__(self):
-        self._schedule = ScheduleRepository()
-        self._yahoo_nba_fantasy = RosterRepository()
+    def __init__(self, **kwargs):
+        self._sched_repo = ScheduleRepository()
+        self._roster_repo = RosterRepository(**kwargs)
     
 
     @timer
-    def main(self, league_id, weeks):
-        weekly_games_per_team = self._schedule.get_weekly_game_count_per_team(weeks)
-        team_rosters = self._yahoo_nba_fantasy.get_active_rosters(league_id)
+    def main(self, league_id, weeks, **kwargs):
+        weekly_games_per_team = self._sched_repo.get_weekly_game_count_per_team(weeks)
+        team_rosters = self._roster_repo.get_active_rosters(league_id, **kwargs)
         self._generate_games_per_week(weekly_games_per_team, team_rosters)
 
 
@@ -61,10 +61,8 @@ class WeeklyTeamGamesCounter(object):
             except KeyError:
                 print("\t{} not found".format(player["team"]))
         return team_games_this_week
-        
-
 
 
 if __name__ == "__main__":
-    games_counter = WeeklyTeamGamesCounter()
-    games_counter.main(10156, [22, 23, 24])
+    games_counter = WeeklyTeamGamesCounter(headless=True)
+    games_counter.main(50972, [22, 23, 24])

--- a/weekly_team_games_counter.py
+++ b/weekly_team_games_counter.py
@@ -1,28 +1,22 @@
-from selenium import webdriver
-import getpass
-import json
 import os
+import sys
+import json
 
 from schedule_repository import ScheduleRepository
-from yahoo_auth import YahooAuth
 from roster_repository import RosterRepository
 from config import headless_chrome_options, YAHOO_FANTASY_URL
 from utils.timer import timer
 
 class WeeklyTeamGamesCounter(object):
     def __init__(self):
-        self._driver = webdriver.Chrome(chrome_options=headless_chrome_options)
         self._schedule = ScheduleRepository()
-        self._yahoo_auth = YahooAuth(self._driver)
-        self._yahoo_nba_fantasy = RosterRepository(self._driver)
+        self._yahoo_nba_fantasy = RosterRepository()
     
 
     @timer
-    def main(self, username, password, league_id, weeks):
+    def main(self, league_id, weeks):
         weekly_games_per_team = self._schedule.get_weekly_game_count_per_team(weeks)
-        self._yahoo_auth.login(username, password, YAHOO_FANTASY_URL + "/nba/" + str(league_id))
         team_rosters = self._yahoo_nba_fantasy.get_active_rosters(league_id)
-
         self._generate_games_per_week(weekly_games_per_team, team_rosters)
 
 
@@ -72,7 +66,5 @@ class WeeklyTeamGamesCounter(object):
 
 
 if __name__ == "__main__":
-    username = input("Enter Yahoo username/email: ")
-    password = getpass.getpass(prompt="Enter Yahoo password: ")
     games_counter = WeeklyTeamGamesCounter()
-    games_counter.main(username, password, 10156, [22, 23, 24])
+    games_counter.main(10156, [22, 23, 24])


### PR DESCRIPTION
* Use decorator in YahooAuth to ensure Yahoo login prior to execution of decorated method
* Store Yahoo session through cookies so that succeeding logins will not require input of credentials
* Remove support for running in headless mode